### PR TITLE
Release 0.4.0 for MC 1.19.3

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -3,9 +3,9 @@ org.gradle.jvmargs=-Xmx1G
 
 # Fabric Properties
 	# check these on https://fabricmc.net/develop
-	minecraft_version=1.19.2
-	yarn_mappings=1.19.2+build.28
-	loader_version=0.14.18
+	minecraft_version=1.19.3
+	yarn_mappings=1.19.3+build.5
+	loader_version=0.14.19
 
 # Mod Properties
 	mod_version = 0.4.0-0.0.1
@@ -14,4 +14,4 @@ org.gradle.jvmargs=-Xmx1G
 
 # Dependencies
 	#Fabric api
-	fabric_version=0.76.0+1.19.2
+	fabric_version=0.76.1+1.19.3

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,7 +8,7 @@ org.gradle.jvmargs=-Xmx1G
 	loader_version=0.14.18
 
 # Mod Properties
-	mod_version = 0.3.0
+	mod_version = 0.4.0-0.0.1
 	maven_group = com.noitcereon
 	archives_base_name = fabric-simple-sorting-mod
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -10,7 +10,7 @@ org.gradle.jvmargs=-Xmx1G
 # Mod Properties
 	mod_version = 0.4.0-0.0.1
 	maven_group = com.noitcereon
-	archives_base_name = fabric-simple-sorting-mod
+	archives_base_name = noits-simple-sorting
 
 # Dependencies
 	#Fabric api

--- a/src/main/java/com/noitcereon/simplesorting/SimpleSortingModClient.java
+++ b/src/main/java/com/noitcereon/simplesorting/SimpleSortingModClient.java
@@ -33,10 +33,18 @@ public class SimpleSortingModClient implements ClientModInitializer {
 
     @NotNull
     private ButtonWidget createSortButton(int scaledWidth, int scaledHeight) {
-        return new ButtonWidget((scaledWidth / 100) * 70, (scaledHeight / 100) * 5, 40, 16, Text.literal("Sort"), (btn) -> {
+        int placementCoordinateX = (scaledWidth / 100) * 70;
+        int placementCoordinateY = (scaledHeight / 100) * 5;
+        int buttonWidth = 40;
+        int buttonHeight = 16;
+
+        ButtonWidget.Builder buttonBuilder = ButtonWidget.builder(Text.literal("Sort"), button -> {
             SimpleSortingMod.LOGGER.debug("Sort Button pressed");
             PacketByteBuf packet = PacketByteBufs.empty();
             ClientPlayNetworking.send(SimpleSortingMod.INVENTORY_SORT_REQUEST_ID, packet); // this triggers the global receiver registered with the same identifier.
-        });
+        })
+        .dimensions(placementCoordinateX, placementCoordinateY, buttonWidth, buttonHeight);
+
+        return buttonBuilder.build();
     }
 }


### PR DESCRIPTION
## Changes
- The default generated jar file is now named noits-simple-sorting-[version-number].jar
   *  Example: `noits-simple-sorting-0.4.0.jar`
- Refactor the way the sort button is created. This also fixes the issue with version 1.19.3 being incompatible.
- Update fabric properies in gradle.properties to match minecraft version 1.19.3

Merging this pull request closes #4