### PR TITLE
Update Continuous Integration pipeline

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: validate gradle wrapper
         uses: gradle/wrapper-validation-action@v1
       - name: setup jdk ${{ matrix.java }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,7 +33,7 @@ jobs:
         run: ./gradlew build
       - name: capture build artifacts
         if: ${{ runner.os == 'Linux' && matrix.java == '17' }} # Only upload artifacts built from latest java on one OS
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: Artifacts
           path: build/libs/

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,8 +23,9 @@ jobs:
       - name: validate gradle wrapper
         uses: gradle/wrapper-validation-action@v1
       - name: setup jdk ${{ matrix.java }}
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v3
         with:
+          distribution: 'temurin'
           java-version: ${{ matrix.java }}
       - name: make gradle wrapper executable
         if: ${{ runner.os != 'Windows' }}


### PR DESCRIPTION
The plan is to update to the latest versions of the Github actions being used, to keep the CI up to date.

## Planned Changes
- [x] [actions/setup-java](https://github.com/actions/setup-java)@v1 -> v3
- [x] [actions/upload-artifact](https://github.com/actions/upload-artifact)@v2 -> v3
- [x] [actions/checkout](https://github.com/actions/checkout)@v2 ->v3
