### PR TITLE
Update for MC 1.20.4

### DIFF
--- a/docs/dev-documentation/update-to-new-minecraft-version.md
+++ b/docs/dev-documentation/update-to-new-minecraft-version.md
@@ -1,0 +1,11 @@
+# Updating to New Minecraft Version
+
+To update to a new Minecraft version you must do the following:
+
+1. Update dependencies, e.g.
+   * YetAnotherConfigLib (https://github.com/isXander/YetAnotherConfigLib)
+   * Fabric (check these on https://fabricmc.net/develop)
+2. Check Minecraft patch notes to see if there is anything that affects this mod. E.g. Java version upgrade.
+3. Test if sorting still works (`gradlew.bat clean build runClient`)
+4. Fix bugs, if any (and go back to step 3)
+5. Release new version (both on GitHub and CurseForge)

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,16 +3,16 @@ org.gradle.jvmargs=-Xmx1G
 
 # Fabric Properties
 # check these on https://fabricmc.net/develop
-minecraft_version=1.20.1
-yarn_mappings=1.20.1+build.10
+minecraft_version=1.20.4
+yarn_mappings=1.20.4+build.3
 loader_version=0.15.11
 
 # Mod Properties
-mod_version = 0.7.0+1.20.1
+mod_version = 0.7.0+1.20.4
 maven_group = com.noitcereon
 archives_base_name = noits-simple-sorting
 
 # Dependencies
 # Fabric API
-fabric_version=0.92.2+1.20.1
-yet_another_config_lib_version=3.5.0+1.20.1-fabric
+fabric_version=0.97.1+1.20.4
+yet_another_config_lib_version=3.5.0+1.20.4-fabric


### PR DESCRIPTION
## Changes
- Update dependencies to match Minecraft v1.20.4
- Add `update-to-new-minecraft-version` developer documentation.