### PR TITLE
Upgrade "upload-artifact" from v3 to v4 in GitHub Actions Workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
       matrix:
         # Use these Java versions
         java: [
-          21,    # Current Java LTS & minimum supported by Minecraft
+          21    # Current Java LTS & minimum supported by Minecraft
         ]
         # and run on both Linux and Windows
         # See https://github.com/actions/runner-images/tree/main for list of available OS versions.
@@ -35,7 +35,8 @@ jobs:
         run: ./gradlew build
       - name: capture build artifacts
         if: ${{ runner.os == 'Linux' && matrix.java == '21' }} # Only upload artifacts built from latest java on one OS
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: Artifacts
+          overwrite: true
           path: build/libs/


### PR DESCRIPTION
Because v3 is deprecated and will not be available after end of jan 2025. See https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/